### PR TITLE
feat: redesign home and wallet pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# WalletConnect Cloud Project ID required for RainbowKit mobile wallets
+NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # WalletConnect Cloud Project ID required for RainbowKit mobile wallets
-NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
+# The default value below is the shared reOwn project; override it locally if you
+# need to use a different WalletConnect workspace.
+NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=11cf43f9159b72fb3a1ca6a26a599305

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Wallet connectivity relies on WalletConnect v2. Create a project at [cloud.walle
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_walletconnect_project_id
 ```
 
-The repository ships with a shared reOwn project ID (`11cf43f9159b72fb3a1ca6a26a599305`) so the app works out of the box, but you can override it at any time by defining the variable above. Without a valid Project ID, the MetaMask option in the RainbowKit modal cannot open the wallet on mobile and WalletConnect-compatible EVM wallets will fail to connect.
+The repository ships with a shared reOwn project ID (`11cf43f9159b72fb3a1ca6a26a599305`) so the app works out of the box, but you can override it at any time by defining the variable above. Without a valid Project ID, the MetaMask option in the RainbowKit modal cannot open the wallet on mobile and WalletConnect-compatible EVM wallets will fail to connect. The bundled Wagmi configuration targets Ethereum mainnet, Base, and Arbitrum so the wallet selector focuses on the primary EVM networks in scope.
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Wallet connectivity relies on WalletConnect v2. Create a project at [cloud.walle
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_walletconnect_project_id
 ```
 
-Without a valid Project ID, the MetaMask option in the RainbowKit modal cannot open the wallet on mobile and WalletConnect-compatible EVM wallets will fail to connect.
+The repository ships with a shared reOwn project ID (`11cf43f9159b72fb3a1ca6a26a599305`) so the app works out of the box, but you can override it at any time by defining the variable above. Without a valid Project ID, the MetaMask option in the RainbowKit modal cannot open the wallet on mobile and WalletConnect-compatible EVM wallets will fail to connect.
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Environment variables
+
+Wallet connectivity relies on WalletConnect v2. Create a project at [cloud.walletconnect.com](https://cloud.walletconnect.com) and expose the generated Project ID to the app. During local development add a `.env.local` file in the project root that contains:
+
+```
+NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_walletconnect_project_id
+```
+
+Without a valid Project ID, the MetaMask option in the RainbowKit modal cannot open the wallet on mobile and WalletConnect-compatible EVM wallets will fail to connect.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/package.json
+++ b/package.json
@@ -9,32 +9,32 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@radix-ui/react-progress": "^1.1.7",
-    "@radix-ui/react-separator": "^1.1.7",
-    "@radix-ui/react-slot": "^1.2.3",
-    "@rainbow-me/rainbowkit": "^2.2.8",
-    "@tanstack/react-query": "^5.87.4",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
-    "lucide-react": "^0.544.0",
+    "@radix-ui/react-progress": "1.1.7",
+    "@radix-ui/react-separator": "1.1.7",
+    "@radix-ui/react-slot": "1.2.3",
+    "@rainbow-me/rainbowkit": "2.2.8",
+    "@tanstack/react-query": "5.89.0",
+    "class-variance-authority": "0.7.1",
+    "clsx": "2.1.1",
+    "lucide-react": "0.544.0",
     "next": "15.5.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "tailwind-merge": "^3.3.1",
-    "viem": "^2.37.5",
-    "wagmi": "^2.16.9",
-    "zustand": "^5.0.8"
+    "tailwind-merge": "3.3.1",
+    "viem": "2.37.6",
+    "wagmi": "2.16.9",
+    "zustand": "5.0.8"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3",
-    "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "eslint": "^9",
+    "@eslint/eslintrc": "3.3.1",
+    "@tailwindcss/postcss": "4.1.13",
+    "@types/node": "20.19.16",
+    "@types/react": "19.1.13",
+    "@types/react-dom": "19.1.9",
+    "eslint": "9.35.0",
     "eslint-config-next": "15.5.3",
-    "tailwindcss": "^4",
-    "tw-animate-css": "^1.3.8",
-    "typescript": "^5"
+    "tailwindcss": "4.1.13",
+    "tw-animate-css": "1.3.8",
+    "typescript": "5.9.2"
   }
 }

--- a/src/app/nft/presale/page.tsx
+++ b/src/app/nft/presale/page.tsx
@@ -1,68 +1,237 @@
 "use client";
 
-import { useMemo } from "react";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Progress } from "@/components/ui/progress";
-import { useAccount } from "wagmi";
+import type { LucideIcon } from "lucide-react";
+import {
+  Clover,
+  Feather,
+  Gem,
+  Sparkles,
+  Star,
+} from "lucide-react";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
+import { useAccount } from "wagmi";
+
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
 
 type PresaleItem = {
   id: string;
-  image?: string;
   maxSupply: number;
   minted: number;
   priceEth: number;
+  accent: string;
+  icon: LucideIcon;
+  iconBg: string;
+  iconTint: string;
 };
 
-const mock: PresaleItem[] = [
-  { id: "001", maxSupply: 1000, minted: 290, priceEth: 0.015 },
-  { id: "002", maxSupply: 1000, minted: 480, priceEth: 0.015 },
-  { id: "003", maxSupply: 1000, minted: 160, priceEth: 0.015 },
-  { id: "004", maxSupply: 1000, minted: 320, priceEth: 0.015 },
-  { id: "005", maxSupply: 1000, minted: 780, priceEth: 0.015 },
+const presaleItems: PresaleItem[] = [
+  {
+    id: "001",
+    maxSupply: 1000,
+    minted: 290,
+    priceEth: 0.015,
+    accent: "from-emerald-500/35 via-emerald-500/15 to-transparent",
+    icon: Sparkles,
+    iconBg: "bg-emerald-500/15",
+    iconTint: "text-emerald-100",
+  },
+  {
+    id: "002",
+    maxSupply: 1000,
+    minted: 480,
+    priceEth: 0.015,
+    accent: "from-sky-400/40 via-emerald-500/10 to-transparent",
+    icon: Gem,
+    iconBg: "bg-sky-500/15",
+    iconTint: "text-sky-100",
+  },
+  {
+    id: "003",
+    maxSupply: 1000,
+    minted: 160,
+    priceEth: 0.015,
+    accent: "from-purple-500/30 via-emerald-500/10 to-transparent",
+    icon: Star,
+    iconBg: "bg-purple-500/15",
+    iconTint: "text-purple-100",
+  },
+  {
+    id: "004",
+    maxSupply: 1000,
+    minted: 320,
+    priceEth: 0.015,
+    accent: "from-amber-400/35 via-emerald-500/10 to-transparent",
+    icon: Feather,
+    iconBg: "bg-amber-400/15",
+    iconTint: "text-amber-100",
+  },
+  {
+    id: "005",
+    maxSupply: 1000,
+    minted: 780,
+    priceEth: 0.015,
+    accent: "from-rose-400/35 via-emerald-500/10 to-transparent",
+    icon: Clover,
+    iconBg: "bg-rose-400/15",
+    iconTint: "text-rose-100",
+  },
 ];
 
 export default function PresalePage() {
-  const { address, isConnected } = useAccount();
+  const { isConnected } = useAccount();
 
   return (
-    <div className="container mx-auto px-4 py-6 max-w-3xl">
-      <div className="flex items-center justify-between mb-4">
-        <h1 className="text-xl font-medium">Presale</h1>
-        <div className="hidden md:block">
-          <ConnectButton />
-        </div>
-      </div>
-      <div className="md:hidden mb-4">
-        <ConnectButton />
-      </div>
+    <div className="relative isolate min-h-[calc(100dvh-4rem)] overflow-hidden bg-[#05060A] text-white">
+      <BackgroundAura />
+      <main className="relative mx-auto flex w-full max-w-xl flex-col gap-8 px-6 pb-24 pt-12">
+        <header className="flex flex-col gap-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-2">
+              <span className="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.5em] text-emerald-200">
+                NFT
+              </span>
+              <h1 className="text-3xl font-semibold uppercase tracking-[0.2em] text-white">
+                Presale
+              </h1>
+              <p className="max-w-sm text-sm leading-relaxed text-white/65">
+                Secure your Hash Butterfly editions before the public drop and unlock early community rewards.
+              </p>
+            </div>
+            <ConnectPill />
+          </div>
+          <p className="text-xs uppercase tracking-[0.4em] text-emerald-200/60">
+            Limited series minting event
+          </p>
+        </header>
+        <section className="flex flex-col gap-3">
+          {presaleItems.map((item) => {
+            const mintedPercent = Math.min(100, (item.minted / item.maxSupply) * 100);
 
-      <div className="space-y-4">
-        {mock.map((item) => (
-          <Card key={item.id} className="bg-card/80 border-white/10">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-base font-semibold">{item.id}</CardTitle>
-              <Button className="bg-primary hover:bg-primary/90" disabled={!isConnected}>
-                BUY
-              </Button>
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-center gap-3 text-xs text-foreground/70">
-                <Badge variant="outline" className="border-primary text-primary">Number {item.maxSupply}</Badge>
-                <Badge variant="outline" className="border-primary text-primary">Price {item.priceEth} Ξ</Badge>
-              </div>
-              <div className="mt-3">
-                <Progress value={(item.minted / item.maxSupply) * 100} />
-                <div className="mt-1 text-xs text-foreground/60">
-                  {item.minted} / {item.maxSupply} minted
+            return (
+              <article
+                key={item.id}
+                className="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-5 shadow-[0_40px_120px_-60px_rgba(16,185,129,0.55)]"
+              >
+                <div className={`absolute inset-0 -z-10 bg-gradient-to-br ${item.accent} opacity-60`} aria-hidden />
+                <div className="flex flex-col gap-4">
+                  <div className="flex items-center justify-between gap-4">
+                    <span className="flex items-center gap-4">
+                      <span className={`relative grid size-12 place-items-center overflow-hidden rounded-2xl border border-emerald-400/30 ${item.iconBg}`}>
+                        <item.icon className={`size-6 ${item.iconTint}`} strokeWidth={1.5} />
+                      </span>
+                      <span className="flex flex-col gap-1">
+                        <span className="text-xs uppercase tracking-[0.5em] text-emerald-200/70">Hash Butterfly</span>
+                        <span className="text-lg font-semibold uppercase tracking-[0.2em] text-white">{item.id}</span>
+                      </span>
+                    </span>
+                    <Button
+                      type="button"
+                      disabled={!isConnected}
+                      className="rounded-full border border-emerald-400/50 bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-400 px-5 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-[#041710] shadow-[0_20px_50px_-28px_rgba(74,222,128,0.9)] transition hover:from-emerald-300 hover:via-emerald-400 hover:to-emerald-300 disabled:border-emerald-400/30 disabled:from-emerald-500/30 disabled:via-emerald-500/30 disabled:to-emerald-500/30 disabled:text-emerald-100/70"
+                    >
+                      Buy
+                    </Button>
+                  </div>
+                  <div className="flex flex-wrap gap-2 text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-emerald-200/80">
+                    <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1">
+                      Number {item.maxSupply.toLocaleString("en-US")}
+                    </span>
+                    <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1">
+                      Price {item.priceEth.toFixed(3)} Ξ
+                    </span>
+                  </div>
+                  <div className="space-y-2">
+                    <Progress
+                      value={mintedPercent}
+                      className="h-1.5 bg-white/10 [&>[data-slot=progress-indicator]]:bg-emerald-400"
+                    />
+                    <div className="flex items-center justify-between text-[0.6rem] uppercase tracking-[0.35em] text-white/50">
+                      <span>Minted</span>
+                      <span>
+                        {item.minted.toLocaleString("en-US")} / {item.maxSupply.toLocaleString("en-US")}
+                      </span>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+              </article>
+            );
+          })}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+function ConnectPill() {
+  return (
+    <ConnectButton.Custom>
+      {({
+        account,
+        chain,
+        authenticationStatus,
+        mounted,
+        openAccountModal,
+        openChainModal,
+        openConnectModal,
+      }) => {
+        const ready = mounted && authenticationStatus !== "loading";
+        const connected =
+          ready &&
+          account &&
+          chain &&
+          (!authenticationStatus || authenticationStatus === "authenticated");
+
+        return (
+          <div
+            {...(!ready && {
+              "aria-hidden": true,
+              style: {
+                opacity: 0,
+                pointerEvents: "none",
+                userSelect: "none",
+              } as const,
+            })}
+          >
+            {!connected ? (
+              <button
+                type="button"
+                onClick={openConnectModal}
+                className="rounded-full border border-emerald-400/50 bg-emerald-500/10 px-4 py-2 text-[0.6rem] font-semibold uppercase tracking-[0.4em] text-emerald-200 transition hover:border-emerald-300 hover:bg-emerald-500/20 hover:text-emerald-100"
+              >
+                Connect
+              </button>
+            ) : chain.unsupported ? (
+              <button
+                type="button"
+                onClick={openChainModal}
+                className="rounded-full border border-red-400/60 bg-red-500/10 px-4 py-2 text-[0.6rem] font-semibold uppercase tracking-[0.4em] text-red-200 transition hover:border-red-300 hover:bg-red-500/20"
+              >
+                Wrong network
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={openAccountModal}
+                className="rounded-full border border-emerald-400/50 bg-emerald-500/10 px-4 py-2 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-emerald-200 transition hover:border-emerald-300 hover:bg-emerald-500/20 hover:text-emerald-100"
+              >
+                {account.displayName}
+              </button>
+            )}
+          </div>
+        );
+      }}
+    </ConnectButton.Custom>
+  );
+}
+
+function BackgroundAura() {
+  return (
+    <div className="absolute inset-0 -z-20 overflow-hidden">
+      <div className="absolute -left-32 top-24 h-72 w-72 rounded-full bg-emerald-500/25 blur-[120px]" aria-hidden />
+      <div className="absolute right-[-120px] top-10 h-80 w-80 rounded-full bg-emerald-400/15 blur-[140px]" aria-hidden />
+      <div className="absolute bottom-[-160px] left-1/2 h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-emerald-500/10 blur-[150px]" aria-hidden />
+      <div className="absolute inset-x-10 top-20 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" aria-hidden />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,182 @@
+import type { SVGProps } from "react";
 import Link from "next/link";
+import { ArrowRight, Sparkles } from "lucide-react";
+
 import { Button } from "@/components/ui/button";
+
+const featureCards = [
+  {
+    slug: "nft",
+    badge: "NFT",
+    title: "Hash butterfly digital art piece",
+    description:
+      "Collect generative wings minted on-chain and unlock privileges across the Hash Butterfly metaverse.",
+    href: "/nft/presale",
+    cta: "Go to presale",
+    gradient: "from-emerald-500/20 via-emerald-500/10 to-transparent",
+  },
+  {
+    slug: "mall",
+    badge: "Mall",
+    title: "Hash Butterfly is superlative",
+    description:
+      "Experience curated drops, IRL collaborations and lifestyle products inspired by the Hash Butterfly IP.",
+    href: "/mall",
+    cta: "Enter mall",
+    gradient: "from-emerald-500/15 via-emerald-500/5 to-purple-500/15",
+  },
+];
+
+const tokenStats = [
+  { label: "Token name", value: "BUTTERFLY" },
+  { label: "Public chain", value: "Ethereum chain" },
+  { label: "Issuance quantity", value: "8.00 trillion" },
+];
+
+const asciiRows = Array.from({ length: 10 }, () => "11111111111111111111111111111111111111");
 
 export default function Home() {
   return (
-    <div className="min-h-[calc(100dvh-4rem)] px-6 py-10 mx-auto max-w-3xl">
-      <h1 className="text-3xl font-semibold tracking-tight mb-3">Hash Butterfly</h1>
-      <p className="text-foreground/70 mb-8">
-        Metaverse IP ecosystem — mobile-first NFT presale and commerce experience built with
-        Next.js, Tailwind and wagmi.
-      </p>
-      <div className="flex gap-3">
-        <Button asChild>
-          <Link href="/nft/presale">Go to Presale</Link>
-        </Button>
-        <Button variant="outline" asChild>
-          <Link href="/wallet">Wallet</Link>
-        </Button>
-      </div>
+    <div className="relative isolate min-h-[calc(100dvh-4rem)] overflow-hidden bg-[#05060A] text-white">
+      <BackgroundAura />
+      <main className="relative mx-auto flex w-full max-w-xl flex-col gap-10 px-6 pb-24 pt-12">
+        <Hero />
+        <section className="space-y-4">
+          {featureCards.map((feature) => (
+            <article
+              key={feature.slug}
+              className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_40px_120px_-60px_rgba(16,185,129,0.45)]"
+            >
+              <div
+                className={`absolute inset-0 -z-10 bg-gradient-to-br ${feature.gradient} opacity-60`}
+                aria-hidden
+              />
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.35em] text-emerald-200/80">
+                  <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 font-semibold">
+                    {feature.badge}
+                  </span>
+                  <span className="font-semibold tracking-[0.5em] text-emerald-200/70">Hash Butterfly</span>
+                </div>
+                <h2 className="text-xl font-semibold uppercase tracking-[0.15em] text-white sm:text-2xl">
+                  {feature.title}
+                </h2>
+                <p className="text-sm leading-relaxed text-white/70">{feature.description}</p>
+                <Button
+                  asChild
+                  variant="outline"
+                  className="group mt-2 inline-flex w-max items-center gap-3 rounded-full border-emerald-400/60 bg-emerald-500/10 px-6 py-5 text-[0.65rem] font-semibold uppercase tracking-[0.4em] text-emerald-200 transition hover:border-emerald-300 hover:bg-emerald-500/20 hover:text-emerald-100"
+                >
+                  <Link href={feature.href}>
+                    {feature.cta}
+                    <ArrowRight className="size-4 -translate-y-px transition-transform group-hover:translate-x-1" />
+                  </Link>
+                </Button>
+              </div>
+              <Sparkles className="absolute -right-6 -top-6 size-20 text-emerald-400/40" aria-hidden />
+            </article>
+          ))}
+        </section>
+        <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6">
+          <div className="absolute inset-x-8 top-0 h-px bg-gradient-to-r from-transparent via-emerald-500/60 to-transparent" aria-hidden />
+          <div className="space-y-4">
+            <span className="inline-flex items-center gap-3 text-xs uppercase tracking-[0.35em] text-emerald-200/80">
+              <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 font-semibold">
+                Ecosystem
+              </span>
+              <span className="tracking-[0.5em] text-emerald-200/70">Hash Butterfly</span>
+            </span>
+            <h2 className="text-xl font-semibold uppercase tracking-[0.2em] text-white sm:text-2xl">
+              Hash Butterfly ecosystem
+            </h2>
+            <p className="text-sm leading-relaxed text-white/70">
+              A connected universe where NFTs, commerce and the community intersect. Explore exclusive launches, immersive
+              storytelling and the loyalty economy surrounding the Hash Butterfly IP.
+            </p>
+            <div className="grid gap-3 sm:grid-cols-3">
+              {tokenStats.map((stat) => (
+                <div
+                  key={stat.label}
+                  className="rounded-2xl border border-white/10 bg-black/40 px-4 py-4 text-left shadow-[0_20px_60px_-40px_rgba(74,222,128,0.6)]"
+                >
+                  <div className="text-[0.6rem] uppercase tracking-[0.4em] text-white/40">{stat.label}</div>
+                  <div className="mt-2 text-lg font-semibold uppercase tracking-[0.1em] text-emerald-200">
+                    {stat.value}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
   );
 }
 
+function Hero() {
+  return (
+    <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 px-6 py-10 text-center">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(74,222,128,0.35),_transparent_60%)] opacity-70" aria-hidden />
+      <div className="pointer-events-none absolute inset-x-0 top-10 flex select-none flex-col items-center text-[0.65rem] font-mono uppercase tracking-[0.75em] text-emerald-500/15">
+        {asciiRows.map((row, index) => (
+          <span key={`${row}-${index}`} className="leading-4">
+            {row}
+          </span>
+        ))}
+      </div>
+      <div className="relative mx-auto flex max-w-sm flex-col items-center gap-6">
+        <div className="inline-flex items-center gap-3 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-4 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.6em] text-emerald-200">
+          Hash Butterfly
+        </div>
+        <ButterflyMark className="size-28 text-emerald-300 drop-shadow-[0_0_32px_rgba(74,222,128,0.45)]" />
+        <div className="space-y-3">
+          <h1 className="text-3xl font-semibold uppercase tracking-[0.2em] text-white sm:text-4xl">
+            Hash butterfly ecosystem
+          </h1>
+          <p className="text-sm leading-relaxed text-white/70">
+            Metaverse IP for digital art, curated commerce and community rewards. Built mobile-first for the next generation of
+            Web3 explorers.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function BackgroundAura() {
+  return (
+    <div className="absolute inset-0 -z-20 overflow-hidden">
+      <div className="absolute -left-40 top-10 h-80 w-80 rounded-full bg-emerald-500/25 blur-[120px]" aria-hidden />
+      <div className="absolute right-0 top-1/3 h-72 w-72 rounded-full bg-emerald-400/20 blur-[120px]" aria-hidden />
+      <div className="absolute -bottom-24 left-1/2 h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-emerald-500/10 blur-[150px]" aria-hidden />
+      <div className="absolute inset-x-12 top-24 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" aria-hidden />
+    </div>
+  );
+}
+
+function ButterflyMark(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M32 36c6.5-9.5 14-14.5 19-16 2.5 5.5-1.5 12.5-6 15.5 5 2 9.5 7.5 8 11.5-4.5-.2-9.5-3.7-12.5-7.2-1.4 3.4-2.9 8.4-4.5 12.4-1.5-4-3-9-4-12.4-3 3.5-8 7-12.5 7.2-1.5-4 3-9.5 8-11.5-4.5-3-8.5-10-6-15.5 5 1.5 12.5 6.5 19 16Z"
+        fill="currentColor"
+        fillOpacity={0.12}
+      />
+      <path
+        d="M32 34c6-8 12-12.5 16.5-13.5 2 4.5-1.2 10-5 12 4.3 1.8 8.2 6.6 7 9.5-3.8-.3-8.2-3.5-11-6.5-1.2 3.1-2.5 7-3.6 10.4-1.2-3.4-2.4-7.3-3.6-10.4-2.8 3-7.2 6.2-11 6.5-1.2-2.9 2.7-7.7 7-9.5-3.8-2-7-7.5-5-12 4.5 1 10.5 5.5 16.5 13.5Z"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx={26} cy={23} r={2.8} fill="currentColor" />
+      <circle cx={38} cy={23} r={2.8} fill="currentColor" />
+      <path
+        d="M30.5 18.5c1.1-1 2.9-1 4 0"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -1,40 +1,169 @@
 "use client";
 
-import { Card, CardContent } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
+import {
+  ArrowRight,
+  Boxes,
+  ReceiptText,
+  Sparkles,
+  Users2,
+  Wallet2,
+} from "lucide-react";
+
+const walletItems = [
+  {
+    title: "My balance",
+    description: "Wallet overview and recent activity",
+    icon: Wallet2,
+    accent: "from-emerald-500/40 via-emerald-500/20 to-transparent",
+  },
+  {
+    title: "My assets",
+    description: "Tokens and collectibles in your vault",
+    icon: Boxes,
+    accent: "from-sky-500/25 via-emerald-500/20 to-transparent",
+  },
+  {
+    title: "My friend",
+    description: "Invite friends and share ecosystem rewards",
+    icon: Users2,
+    accent: "from-purple-500/25 via-emerald-500/15 to-transparent",
+  },
+  {
+    title: "My NFT",
+    description: "Manage your Hash Butterfly editions",
+    icon: Sparkles,
+    accent: "from-emerald-500/30 via-lime-400/30 to-transparent",
+  },
+  {
+    title: "My order",
+    description: "Track purchases across the metaverse mall",
+    icon: ReceiptText,
+    accent: "from-amber-400/30 via-emerald-500/15 to-transparent",
+  },
+];
 
 export default function WalletPage() {
   return (
-    <div className="container mx-auto px-4 py-6 max-w-2xl">
-      <div className="flex items-center justify-between mb-4">
-        <h1 className="text-xl font-medium">Wallet</h1>
-        <ConnectButton />
-      </div>
-      <Card className="bg-card/80 border-white/10">
-        <CardContent className="p-0">
-          <div className="divide-y divide-white/10">
-            <Row title="My balance" hint="View on-chain balance" />
-            <Row title="My assets" hint="NFTs and tokens" />
-            <Row title="My friend" hint="Referrals" />
-            <Row title="My NFT" hint="Owned collectibles" />
-            <Row title="My order" hint="Orders & receipts" />
+    <div className="relative isolate min-h-[calc(100dvh-4rem)] overflow-hidden bg-[#05060A] text-white">
+      <BackgroundAura />
+      <div className="relative mx-auto flex w-full max-w-xl flex-col gap-8 px-6 pb-24 pt-12">
+        <header className="space-y-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-2">
+              <span className="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.5em] text-emerald-200">
+                Wallet
+              </span>
+              <h1 className="text-3xl font-semibold uppercase tracking-[0.2em] text-white">
+                Hash Butterfly
+              </h1>
+              <p className="text-sm leading-relaxed text-white/65">
+                Welcome to the Hash Butterfly Metaverse Ecology
+              </p>
+            </div>
+            <WalletConnectButton />
           </div>
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-function Row({ title, hint }: { title: string; hint: string }) {
-  return (
-    <div className="px-4 py-4 flex items-center justify-between">
-      <div>
-        <div className="font-medium">{title}</div>
-        <div className="text-xs text-foreground/60">{hint}</div>
+          <p className="text-xs uppercase tracking-[0.4em] text-emerald-200/60">
+            Manage digital identity and experiences
+          </p>
+        </header>
+        <section className="flex flex-col gap-3">
+          {walletItems.map((item) => (
+            <button
+              key={item.title}
+              type="button"
+              className="group relative flex items-center justify-between gap-4 rounded-3xl border border-white/10 bg-white/5 px-4 py-4 text-left shadow-[0_30px_90px_-60px_rgba(16,185,129,0.65)] transition hover:border-emerald-400/40 hover:bg-emerald-500/10"
+            >
+              <span className="flex items-center gap-4">
+                <span className="relative grid size-12 place-items-center overflow-hidden rounded-2xl border border-emerald-400/30 bg-emerald-500/10 text-emerald-100">
+                  <span className={`absolute inset-0 -z-10 bg-gradient-to-br ${item.accent} opacity-60`} aria-hidden />
+                  <item.icon className="relative size-5" strokeWidth={1.5} />
+                </span>
+                <span className="flex flex-col gap-1">
+                  <span className="text-base font-semibold uppercase tracking-[0.12em] text-white">
+                    {item.title}
+                  </span>
+                  <span className="text-xs text-white/60">{item.description}</span>
+                </span>
+              </span>
+              <ArrowRight className="size-5 shrink-0 text-emerald-200 transition-transform group-hover:translate-x-1" />
+            </button>
+          ))}
+        </section>
       </div>
-      <span className="text-[--accent-11]">→</span>
     </div>
   );
 }
 
+function WalletConnectButton() {
+  return (
+    <ConnectButton.Custom>
+      {({
+        account,
+        chain,
+        authenticationStatus,
+        mounted,
+        openAccountModal,
+        openChainModal,
+        openConnectModal,
+      }) => {
+        const ready = mounted && authenticationStatus !== "loading";
+        const connected =
+          ready &&
+          account &&
+          chain &&
+          (!authenticationStatus || authenticationStatus === "authenticated");
+
+        return (
+          <div
+            {...(!ready && {
+              "aria-hidden": true,
+              style: {
+                opacity: 0,
+                pointerEvents: "none",
+                userSelect: "none",
+              } as const,
+            })}
+          >
+            {!connected ? (
+              <button
+                type="button"
+                onClick={openConnectModal}
+                className="rounded-full border border-emerald-400/50 bg-emerald-500/10 px-4 py-2 text-[0.6rem] font-semibold uppercase tracking-[0.4em] text-emerald-200 transition hover:border-emerald-300 hover:bg-emerald-500/20 hover:text-emerald-100"
+              >
+                Connect
+              </button>
+            ) : chain.unsupported ? (
+              <button
+                type="button"
+                onClick={openChainModal}
+                className="rounded-full border border-red-400/60 bg-red-500/10 px-4 py-2 text-[0.6rem] font-semibold uppercase tracking-[0.4em] text-red-200 transition hover:border-red-300 hover:bg-red-500/20"
+              >
+                Wrong network
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={openAccountModal}
+                className="rounded-full border border-emerald-400/50 bg-emerald-500/10 px-4 py-2 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-emerald-200 transition hover:border-emerald-300 hover:bg-emerald-500/20 hover:text-emerald-100"
+              >
+                {account.displayName}
+              </button>
+            )}
+          </div>
+        );
+      }}
+    </ConnectButton.Custom>
+  );
+}
+
+function BackgroundAura() {
+  return (
+    <div className="absolute inset-0 -z-20 overflow-hidden">
+      <div className="absolute -left-32 top-24 h-72 w-72 rounded-full bg-emerald-500/25 blur-[120px]" aria-hidden />
+      <div className="absolute right-[-120px] top-10 h-80 w-80 rounded-full bg-emerald-400/15 blur-[140px]" aria-hidden />
+      <div className="absolute bottom-[-160px] left-1/2 h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-emerald-500/10 blur-[150px]" aria-hidden />
+      <div className="absolute inset-x-10 top-20 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" aria-hidden />
+    </div>
+  );
+}

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -1,4 +1,11 @@
-import { getDefaultConfig } from "@rainbow-me/rainbowkit";
+import { connectorsForWallets } from "@rainbow-me/rainbowkit";
+import {
+  metaMaskWallet,
+  walletConnectWallet,
+  coinbaseWallet,
+  injectedWallet,
+} from "@rainbow-me/rainbowkit/wallets";
+import { createConfig, http } from "wagmi";
 import { arbitrum, base, mainnet } from "wagmi/chains";
 
 const fallbackProjectId = "11cf43f9159b72fb3a1ca6a26a599305";
@@ -14,11 +21,30 @@ if (/^0+$/.test(walletConnectProjectId)) {
 
 const chains = [mainnet, base, arbitrum] as const;
 
-// RainbowKit provides a helper to create a Wagmi config with sensible defaults
-export const wagmiConfig = getDefaultConfig({
-  appName: "NFT Sale DApp",
-  projectId: walletConnectProjectId,
+const connectors = connectorsForWallets([
+  {
+    groupName: "Recommended",
+    wallets: [
+      metaMaskWallet({
+        projectId: walletConnectProjectId,
+        chains,
+        extensionOnly: true,
+      }),
+      coinbaseWallet({ appName: "NFT Sale DApp", chains }),
+      injectedWallet({ chains, shimDisconnect: true }),
+      walletConnectWallet({ projectId: walletConnectProjectId, chains }),
+    ],
+  },
+]);
+
+export const wagmiConfig = createConfig({
   chains,
+  connectors,
   ssr: true,
+  transports: {
+    [mainnet.id]: http(),
+    [base.id]: http(),
+    [arbitrum.id]: http(),
+  },
 });
 

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -1,5 +1,5 @@
 import { getDefaultConfig } from "@rainbow-me/rainbowkit";
-import { arbitrum, base, bsc, mainnet, optimism, polygon, sepolia } from "wagmi/chains";
+import { arbitrum, base, mainnet } from "wagmi/chains";
 
 const fallbackProjectId = "11cf43f9159b72fb3a1ca6a26a599305";
 
@@ -12,7 +12,7 @@ if (/^0+$/.test(walletConnectProjectId)) {
   );
 }
 
-const chains = [mainnet, sepolia, polygon, arbitrum, optimism, base, bsc] as const;
+const chains = [mainnet, base, arbitrum] as const;
 
 // RainbowKit provides a helper to create a Wagmi config with sensible defaults
 export const wagmiConfig = getDefaultConfig({

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -1,18 +1,21 @@
-import { http, createConfig } from "wagmi";
-import { mainnet, sepolia } from "wagmi/chains";
 import { getDefaultConfig } from "@rainbow-me/rainbowkit";
+import { arbitrum, base, bsc, mainnet, optimism, polygon, sepolia } from "wagmi/chains";
 
-const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || "00000000000000000000000000000000";
+const walletConnectProjectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID;
+
+if (!walletConnectProjectId || /^0+$/.test(walletConnectProjectId)) {
+  throw new Error(
+    "Missing NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID. Generate a WalletConnect Cloud project ID and expose it as NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID to enable MetaMask and other EVM wallets.",
+  );
+}
+
+const chains = [mainnet, sepolia, polygon, arbitrum, optimism, base, bsc] as const;
 
 // RainbowKit provides a helper to create a Wagmi config with sensible defaults
 export const wagmiConfig = getDefaultConfig({
   appName: "NFT Sale DApp",
-  projectId,
-  chains: [mainnet, sepolia],
-  transports: {
-    [mainnet.id]: http(),
-    [sepolia.id]: http(),
-  },
+  projectId: walletConnectProjectId,
+  chains,
   ssr: true,
 });
 

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -23,23 +23,28 @@ if (/^0+$/.test(walletConnectProjectId)) {
 
 const chains = [mainnet, base, arbitrum] as const;
 
-const connectors = connectorsForWallets([
+const connectors = connectorsForWallets(
+  [
+    {
+      groupName: "Recommended",
+      wallets: [
+        (walletOptions) =>
+          metaMaskWallet({
+            ...walletOptions,
+          }),
+        rabbyWallet,
+        okxWallet,
+        (walletOptions) => coinbaseWallet(walletOptions),
+        injectedWallet,
+        walletConnectWallet,
+      ],
+    },
+  ],
   {
-    groupName: "Recommended",
-    wallets: [
-      metaMaskWallet({
-        projectId: walletConnectProjectId,
-        chains,
-        extensionOnly: true,
-      }),
-      rabbyWallet(),
-      okxWallet({ projectId: walletConnectProjectId, chains }),
-      coinbaseWallet({ appName: "NFT Sale DApp", chains }),
-      injectedWallet({ chains, shimDisconnect: true }),
-      walletConnectWallet({ projectId: walletConnectProjectId, chains }),
-    ],
+    appName: "Hash Butterfly",
+    projectId: walletConnectProjectId,
   },
-]);
+);
 
 export const wagmiConfig = createConfig({
   chains,

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -4,6 +4,8 @@ import {
   walletConnectWallet,
   coinbaseWallet,
   injectedWallet,
+  rabbyWallet,
+  okxWallet,
 } from "@rainbow-me/rainbowkit/wallets";
 import { createConfig, http } from "wagmi";
 import { arbitrum, base, mainnet } from "wagmi/chains";
@@ -30,6 +32,8 @@ const connectors = connectorsForWallets([
         chains,
         extensionOnly: true,
       }),
+      rabbyWallet(),
+      okxWallet({ projectId: walletConnectProjectId, chains }),
       coinbaseWallet({ appName: "NFT Sale DApp", chains }),
       injectedWallet({ chains, shimDisconnect: true }),
       walletConnectWallet({ projectId: walletConnectProjectId, chains }),

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -1,11 +1,14 @@
 import { getDefaultConfig } from "@rainbow-me/rainbowkit";
 import { arbitrum, base, bsc, mainnet, optimism, polygon, sepolia } from "wagmi/chains";
 
-const walletConnectProjectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID;
+const fallbackProjectId = "11cf43f9159b72fb3a1ca6a26a599305";
 
-if (!walletConnectProjectId || /^0+$/.test(walletConnectProjectId)) {
+const walletConnectProjectId =
+  process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID?.trim() || fallbackProjectId;
+
+if (/^0+$/.test(walletConnectProjectId)) {
   throw new Error(
-    "Missing NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID. Generate a WalletConnect Cloud project ID and expose it as NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID to enable MetaMask and other EVM wallets.",
+    "Invalid NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID. Generate a WalletConnect Cloud project ID and expose it as NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID to enable MetaMask and other EVM wallets.",
   );
 }
 


### PR DESCRIPTION
## Summary
- restyled the mobile homepage with hero, feature highlights, and ecosystem stats inspired by the provided concept
- refreshed the wallet page with gradient list tiles and a custom RainbowKit connect CTA to mirror the target design
- added a bespoke butterfly glyph and atmospheric background auras to keep the experience cohesive across both screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c940565a3883218960d1daf4011a75